### PR TITLE
Fix bug causing validators to not be set with def>

### DIFF
--- a/src/roomkey/drcfg.clj
+++ b/src/roomkey/drcfg.clj
@@ -111,7 +111,7 @@
   [symb & args]
   (let [[symb default options] (name-with-attributes-and-options symb args)
         m (meta symb)
-        options (mapcat identity (select-keys options [:validator]))]
+        options (vec (mapcat identity (select-keys options [:validator])))]
     `(let [bpath# (str "/" (string/replace (str *ns*) #"\." "/") "/" '~symb)
            ^roomkey.zref.ZRef z# (apply >- bpath# ~default ~options)]
        (when ~m (znode/add-descendant (.znode z#) "/.metadata" ~m))

--- a/test/roomkey/unit/drcfg.clj
+++ b/test/roomkey/unit/drcfg.clj
@@ -48,3 +48,9 @@
 
 (fact "def> can be evaluated"
       (def> ^:foo y "My Docstring" 2222) => (partial instance? clojure.lang.Var))
+
+(fact "def> can accept a validator"
+       (def> validated-value
+         [2 4 6]
+         :validator #(every? even? %))
+       (get-validator validated-value) => fn?)


### PR DESCRIPTION
I noticed that my validators weren't getting set. I looked into it a bit
and discovered a macro-expansion bug. Previously the macro expansion
looked like this:
```
(let*
  [bpath__27248__auto__
   (str "/" (string/replace (str *ns*) #"\." "/") "/" 'validated-value)
   z__27249__auto__
   (apply
     >-
     bpath__27248__auto__
     [2 4 6]
     (:validator #(every? even? %)))]
  (when {}
    (znode/add-descendant (.znode z__27249__auto__) "/.metadata" {}))
  (def validated-value z__27249__auto__))
```

with the problematic line being
```
(:validator #(every? even? %)))
```
This expression was being evaluated as the keyword function and
returning nil.

I changed the options to a vec to avoid evaluation and passing the
arguments through to the `>-` function